### PR TITLE
refactor: Replace panic with error return in SetupRedis func

### DIFF
--- a/cmd/main.go
+++ b/cmd/main.go
@@ -9,11 +9,11 @@ import (
 )
 
 func main() {
-	var redisClient = config.SetupRedis()
+	var redisClient, err = config.SetupRedis()
 	var c = context.Background()
 	var r output.CacheOutputPort = repository.NewRedisRepository(redisClient)
 
-	var err = r.Set(c, "octocat", "Mona the Octocat")
+	err = r.Set(c, "octocat", "Mona the Octocat")
 	if err != nil {
 		panic(err)
 	}

--- a/internal/infrastructure/adapters/config/redis_config.go
+++ b/internal/infrastructure/adapters/config/redis_config.go
@@ -2,12 +2,12 @@ package config
 
 import "github.com/redis/rueidis"
 
-func SetupRedis() rueidis.Client {
+func SetupRedis() (rueidis.Client, error) {
 	redisClient, err := rueidis.NewClient(rueidis.ClientOption{
 		InitAddress: []string{"localhost:6379"},
 	})
 	if err != nil {
-		panic(err)
+		return nil, err
 	}
-	return redisClient
+	return redisClient, nil
 }


### PR DESCRIPTION
## Description

Replaced panic with error return in SetupRedis func.

**AS-IS**

```go
var redisClient = config.SetupRedis()
```

**TO-BE**

```go
var redisClient, err = config.SetupRedis()
```

