### PR TITLE
refactor: Replace variable declarations with direct returns

### DIFF
--- a/internal/infrastructure/adapters/config/redis_config.go
+++ b/internal/infrastructure/adapters/config/redis_config.go
@@ -3,11 +3,7 @@ package config
 import "github.com/redis/rueidis"
 
 func SetupRedis() (rueidis.Client, error) {
-	redisClient, err := rueidis.NewClient(rueidis.ClientOption{
+	return rueidis.NewClient(rueidis.ClientOption{
 		InitAddress: []string{"localhost:6379"},
 	})
-	if err != nil {
-		return nil, err
-	}
-	return redisClient, nil
 }


### PR DESCRIPTION
## Description

Replaced variable declarations with direct returns.

**AS-IS**

```go
func SetupRedis() (rueidis.Client, error) {
  redisClient, err := rueidis.NewClient(rueidis.ClientOption{
    InitAddress: []string{"localhost:6379"},
  })
  if err != nil {
    return nil, err
  }
  return redisClient, nil
}
```

**TO-BE**

```go
func SetupRedis() (rueidis.Client, error) {
  return rueidis.NewClient(rueidis.ClientOption{
    InitAddress: []string{"localhost:6379"},
  })
}
```